### PR TITLE
Remove harcoded Flickr ID

### DIFF
--- a/ditto/flickr/management/commands/fetch_flickr_account_user.py
+++ b/ditto/flickr/management/commands/fetch_flickr_account_user.py
@@ -47,7 +47,7 @@ class Command(BaseCommand):
                 result = UserFetcher(account=account).fetch(nsid=id_result["id"])
                 if "success" in result and result["success"] is True:
                     # Now we'll associate this User with the Account:
-                    user = User.objects.get(nsid="35034346050@N01")
+                    user = User.objects.get(nsid=id_result["id"])
                     account.user = user
                     account.save()
                     if options.get("verbosity", 1) > 0:


### PR DESCRIPTION
`fetch_flickr_account_user` had a hardcoded Flickr ID which causes it to fail with non-Phils.