### PR TITLE
Guard against unset sizes

### DIFF
--- a/ditto/flickr/fetch/savers.py
+++ b/ditto/flickr/fetch/savers.py
@@ -239,13 +239,13 @@ class PhotoSaver(SaveUtilsMixin, object):
         sizes.remove("Large square")
 
         for size in photo["sizes"]["size"]:
-            if size["label"] in sizes and (
-                size["width"] != None or size["height"] != None
-            ):
+            if size["label"] in sizes:
                 # eg, 'X-Large 3K' becomes 'x_large_3k':
                 name = size["label"].lower().replace(" ", "_").replace("-", "_")
-                defaults[name + "_width"] = int(size["width"])
-                defaults[name + "_height"] = int(size["height"])
+                if size["width"] != None:
+                    defaults[name + "_width"] = int(size["width"])
+                if size["height"] != None:
+                    defaults[name + "_height"] = int(size["height"])
 
         try:
             for e in photo["exif"]["exif"]:

--- a/ditto/flickr/fetch/savers.py
+++ b/ditto/flickr/fetch/savers.py
@@ -239,7 +239,9 @@ class PhotoSaver(SaveUtilsMixin, object):
         sizes.remove("Large square")
 
         for size in photo["sizes"]["size"]:
-            if size["label"] in sizes:
+            if size["label"] in sizes and (
+                size["width"] != None or size["height"] != None
+            ):
                 # eg, 'X-Large 3K' becomes 'x_large_3k':
                 name = size["label"].lower().replace(" ", "_").replace("-", "_")
                 defaults[name + "_width"] = int(size["width"])

--- a/ditto/flickr/fetch/savers.py
+++ b/ditto/flickr/fetch/savers.py
@@ -242,9 +242,9 @@ class PhotoSaver(SaveUtilsMixin, object):
             if size["label"] in sizes:
                 # eg, 'X-Large 3K' becomes 'x_large_3k':
                 name = size["label"].lower().replace(" ", "_").replace("-", "_")
-                if size["width"] != None:
+                if size["width"] is not None:
                     defaults[name + "_width"] = int(size["width"])
-                if size["height"] != None:
+                if size["height"] is not None:
                     defaults[name + "_height"] = int(size["height"])
 
         try:


### PR DESCRIPTION
I've had a few imports fail with: 

```
File "/Users/garrettc/sandbox/django-ditto/ditto/flickr/fetch/savers.py", line 245, in save_photo
    defaults[name + "_width"] = int(size["width"])
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```
Originally I thought it was just videos, but it's also happening on some photos. 

This patch adds a guard for each dimension.