### PR TITLE
Guard against unset realname

### DIFF
--- a/ditto/flickr/fetch/savers.py
+++ b/ditto/flickr/fetch/savers.py
@@ -76,7 +76,7 @@ class UserSaver(SaveUtilsMixin, object):
         if "realname" in user:
             realname = user["realname"]["_content"]
         else:
-            realname = "No realname"
+            realname = user["username"]["_content"]
 
         defaults = {
             "fetch_time": fetch_time,

--- a/ditto/flickr/fetch/savers.py
+++ b/ditto/flickr/fetch/savers.py
@@ -72,6 +72,12 @@ class UserSaver(SaveUtilsMixin, object):
         """
         raw_json = json.dumps(user)
 
+        # Sometimes this isn't set, not sure why
+        if "realname" in user:
+            realname = user["realname"]
+        else:
+            realname = "No realname"
+
         defaults = {
             "fetch_time": fetch_time,
             "raw": raw_json,
@@ -80,7 +86,7 @@ class UserSaver(SaveUtilsMixin, object):
             "iconserver": user["iconserver"],
             "iconfarm": user["iconfarm"],
             "username": user["username"]["_content"],
-            "realname": user["realname"]["_content"],
+            "realname": realname,
             "description": user["description"]["_content"],
             "photos_url": user["photosurl"]["_content"],
             "profile_url": user["profileurl"]["_content"],

--- a/ditto/flickr/fetch/savers.py
+++ b/ditto/flickr/fetch/savers.py
@@ -74,7 +74,7 @@ class UserSaver(SaveUtilsMixin, object):
 
         # Sometimes this isn't set, not sure why
         if "realname" in user:
-            realname = user["realname"]
+            realname = user["realname"]["_content"]
         else:
             realname = "No realname"
 


### PR DESCRIPTION
(guess what I've been doing this evening)

I've come across a couple of instances where `realname` isn't set for the user resulting in a `KeyError`. 

~This adds a guard to set it to a default if it's not set.~

After a few minutes thought it seems better to set it to the username, so it's relevant to the user.